### PR TITLE
Add yarn-basic-checks reusable action

### DIFF
--- a/.github/actions/yarn-basic-checks/action.yml
+++ b/.github/actions/yarn-basic-checks/action.yml
@@ -2,7 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: "Basic Checks and Tests"
-description: "Perform basic checks and tests for an NPM project"
+description: "Perform basic checks and tests for a yarn project"
 inputs:
   node-version:
     required: true
@@ -16,11 +16,12 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
-    - run: npm ci
+    # Yarn equivalent of npm ci.
+    - run: yarn install --frozen-lockfile
       shell: bash
-    - run: npx --no-install prettier --check .
+    - run: yarn prettier --check .
       shell: bash
-    - run: npm run lint
+    - run: yarn lint
       shell: bash
-    - run: npm run test
+    - run: yarn test
       shell: bash


### PR DESCRIPTION
# PULL REQUEST

## Overview

Adds a yarn equivalent for `npm-basic-checks`.

Needed for at least the `skynet-js` and `nodejs-skynet` repos. 

### Note

Note that for `skynet-js` we will have to pass in a couple of env vars:

```yml
env:
  SKYNET_JS_INTEGRATION_TEST_SERVER: "https://skynetpro.net"
  SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY: ${{ secrets.SKYNET_API_KEY }}
```

but otherwise it should be able to use this action.