### PR TITLE
Fix Version-Release action

### DIFF
--- a/.github/actions/version-release/action.yml
+++ b/.github/actions/version-release/action.yml
@@ -8,6 +8,10 @@ inputs:
     required: false
     description: "major, minor, or patch version bump"
     default: "patch"
+outputs:
+  new-version:
+    description: "new version created"
+    value: ${{ steps.tag_version.outputs.new_version }}
 
 runs:
   using: "composite"
@@ -17,7 +21,7 @@ runs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ inputs.github-token }}
-        default_bump: ${{ inputs.version-bump }}
+
     - name: Create a GitHub release
       uses: ncipollo/release-action@v1
       with:


### PR DESCRIPTION
# PULL REQUEST

## Overview
There was a bug in the version release action that was causing it to not trigger a release. The `default_bump` was not needed and causing the issue. 

Addtionally I added outputs to the action to be able to pull the new version in to the docker build action. 

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->
Tested on the `docker-test` repo https://github.com/SkynetLabs/docker-test/actions/runs/2315807354

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
Closes SKY-12