### PR TITLE
Add missing build step to npm and yarn actions

### DIFF
--- a/.github/actions/npm-basic-checks/action.yml
+++ b/.github/actions/npm-basic-checks/action.yml
@@ -7,6 +7,11 @@ inputs:
   node-version:
     required: true
     description: "the node version"
+  build:
+    required: false
+    type: boolean
+    description: "enables the build step"
+    default: false
 
 runs:
   using: "composite"
@@ -22,7 +27,8 @@ runs:
       shell: bash
     - run: npm run lint
       shell: bash
-    - run: npm run build
+    - if: ${{ inputs.build == 'true' }}
+      run: npm run build
       shell: bash
     - run: npm run test
       shell: bash

--- a/.github/actions/npm-basic-checks/action.yml
+++ b/.github/actions/npm-basic-checks/action.yml
@@ -22,5 +22,7 @@ runs:
       shell: bash
     - run: npm run lint
       shell: bash
+    - run: npm run build
+      shell: bash
     - run: npm run test
       shell: bash

--- a/.github/actions/yarn-basic-checks/action.yml
+++ b/.github/actions/yarn-basic-checks/action.yml
@@ -23,5 +23,7 @@ runs:
       shell: bash
     - run: yarn lint
       shell: bash
+    - run: yarn build
+      shell: bash
     - run: yarn test
       shell: bash

--- a/.github/actions/yarn-basic-checks/action.yml
+++ b/.github/actions/yarn-basic-checks/action.yml
@@ -7,6 +7,11 @@ inputs:
   node-version:
     required: true
     description: "the node version"
+  build:
+    required: false
+    type: boolean
+    description: "enables the build step"
+    default: false
 
 runs:
   using: "composite"
@@ -23,7 +28,8 @@ runs:
       shell: bash
     - run: yarn lint
       shell: bash
-    - run: yarn build
+    - if: ${{ inputs.build == 'true' }}
+      run: yarn build
       shell: bash
     - run: yarn test
       shell: bash


### PR DESCRIPTION
# PULL REQUEST

## Overview

This is needed because we just auto-merged a Dependabot PR into
`skynet-mysky-utils` which broke `npm run build`, but passed all the other
checks.

Needed to add the build script to `nodejs`:

https://github.com/SkynetLabs/nodejs-skynet/pull/147