### PR TITLE
Fix bug in docker action

### DIFF
--- a/.github/actions/docker-publish/action.yml
+++ b/.github/actions/docker-publish/action.yml
@@ -23,6 +23,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Needed for calling the major-minor-version action
+    - uses: actions/checkout@v3
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
# PULL REQUEST

## Overview
While the docker actions themselves don't need the checkout action, the overall action needs it in order to see the composite action it is calling. 

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
