### PR TITLE
Update PR template to mention signing

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,11 +2,12 @@
 Please read and fill out this form before submitting your PR.
 
 IMPORTANT:
-Before continuing, please make sure that your commits are signed!
-Setting up signing commits:
-https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
-Signing existing commits:
-https://superuser.com/a/1123928/664691
+Before continuing, please make sure that ALL your commits are signed!
+- Setting up signing commits:
+  https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
+- Signing existing commits:
+  https://superuser.com/a/1123928/664691
+- If that doesn't work, squash your commits and force push one signed commit.
 -->
 
 # PULL REQUEST

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,22 +1,43 @@
+<!--
+IMPORTANT:
+Before continuing, please make sure that your commits are signed!
+Setting up signing commits:
+https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
+Signing existing commits:
+https://superuser.com/a/1123928/664691
+-->
+
 # PULL REQUEST
 
 ## Overview
 
+<!--
+Provide a detailed description of the change.
+-->
+
 ## Example for Visual Changes
+
 <!--
 For user facing features please provide proof that the format is as expected.
 Screen shots and/or asciinema recordings are very helpful.
 -->
 
 ## Checklist
-Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
- - [ ] All new methods or updated methods have clear docstrings
- - [ ] Testing added or updated for new methods
- - [ ] Verify if any changes impact the WebPortal Health Checks
- - [ ] Approriate documentation updated
- - [ ] Changelog file created
+
+<!--
+Review and complete the checklist to ensure that the PR is complete before
+assigned to an approver. Leave blank any that you are unsure about.
+-->
+
+- [ ] All git commits are signed. (REQUIRED)
+- [ ] All new methods or updated methods have clear docstrings.
+- [ ] Testing added or updated for new methods.
+- [ ] Verified if any changes impact the WebPortal Health Checks.
+- [ ] Appropriate documentation updated.
+- [ ] Changelog file created.
 
 ## Issues Closed
+
 <!--
 Use the `Closes` keyword to automatically close the issue on merge.
 Example: Closes #XXXX

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,6 @@
 <!--
+Please read and fill out this form before submitting your PR.
+
 IMPORTANT:
 Before continuing, please make sure that your commits are signed!
 Setting up signing commits:


### PR DESCRIPTION
# PULL REQUEST

## Overview

In the past two days we noticed two community PRs that were not signed. We did
not notice, until the PRs were about to be merged, that the merging was blocked.
We should inform the users as early as possible about this requirement to avoid
friction, minimize the risk of losing valuable contributions, and avoid them
having to remake the PR (in the worst case).

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [X] Approriate documentation updated
 - [ ] Changelog file created